### PR TITLE
Fixes clashes with Scalaz implicits.

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantMonad.scala
+++ b/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantMonad.scala
@@ -21,8 +21,9 @@ import scalaz.{Monad, Plus}
 /**
   * A specialised monad `M[A]` for some operation that produces a `Result[A]`.
   *
-  * `M` needs to be a monad that is relative to [[Result]]. ResultantMonad turns a monad relative to
-  * [[Result]] into an ordinary monad.
+  * `M` needs to be a monad relative to [[Result]] via `rPoint` and `rBind`.
+  * `ResultantMonad` extends this relative monad into an ordinary monad.
+  * See the _relative monad_ concept in "Monads need not be endofunctors" by Altenkirch, Chapman & Uustalu.
   * See the `DB` monad in CommBank/answer for a concrete example.
   */
 trait ResultantMonad[M[_]] extends Plus[M] with Monad[M] {

--- a/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantOps.scala
+++ b/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantOps.scala
@@ -16,27 +16,33 @@ package au.com.cba.omnia.omnitool
 
 import scalaz.syntax.monad._
 
-/** Convenient operations that you can do on the companion of a [[ResultantMonad]]. */
-final class ResultantOps[O, M[_]](self: O)(implicit val M: ResultantMonad[M]) {
+/**
+  * Convenient operations that you can do on the companion of a [[ResultantMonad]].
+  *
+  * The companion object should extend this class to avoid clashing with Scalaz implicits.
+  */
+abstract class ResultantOps[M[_]] {
+  implicit val monad: ResultantMonad[M]
+
   /** Build an operation from a value. The resultant DB operation will not throw an exception. */
   def value[A](v: => A): M[A] =
-    M.point(v)
+    monad.point(v)
 
   /** Builds an operation from a [[Result]]. */
   def result[A](v: => Result[A]): M[A] =
-    M.rPoint(v)
+    monad.rPoint(v)
 
   /** Build a failed operation from the specified message. */
   def fail[A](message: String): M[A] =
-    M.rPoint(Result.fail(message))
+    monad.rPoint(Result.fail(message))
 
   /** Build a failed M operation from the specified exception. */
   def exception[A](t: Throwable): M[A] =
-    M.rPoint(Result.exception(t))
+    monad.rPoint(Result.exception(t))
 
   /** Build a failed M operation from the specified exception and message. */
   def error[A](message: String, t: Throwable): M[A] =
-    M.rPoint(Result.error(message, t))
+    monad.rPoint(Result.error(message, t))
 
   /**
     * Fails if condition is not met
@@ -45,7 +51,7 @@ final class ResultantOps[O, M[_]](self: O)(implicit val M: ResultantMonad[M]) {
     * quite meet the required laws.
     */
   def guard(ok: Boolean, message: String): M[Unit] =
-    M.rPoint(Result.guard(ok, message))
+    monad.rPoint(Result.guard(ok, message))
 
   /**
     * Fails if condition is met
@@ -54,7 +60,7 @@ final class ResultantOps[O, M[_]](self: O)(implicit val M: ResultantMonad[M]) {
     * quite meet the required laws.
     */
   def prevent(fail: Boolean, message: String): M[Unit] =
-    M.rPoint(Result.prevent(fail, message))
+    monad.rPoint(Result.prevent(fail, message))
 
   /**
     * Ensures a M operation returning a boolean success flag fails if unsuccessful

--- a/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantOps.scala
+++ b/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantOps.scala
@@ -21,7 +21,7 @@ import scalaz.syntax.monad._
   *
   * The companion object should extend this class to avoid clashing with Scalaz implicits.
   */
-abstract class ResultantOps[M[_]] {
+trait ResultantOps[M[_]] {
   implicit val monad: ResultantMonad[M]
 
   /** Build an operation from a value. The resultant DB operation will not throw an exception. */

--- a/core/src/test/scala/au/com/cba/omnia/omnitool/test/Resultant.scala
+++ b/core/src/test/scala/au/com/cba/omnia/omnitool/test/Resultant.scala
@@ -20,7 +20,7 @@ import scalaz.Equal
 
 import org.scalacheck.Arbitrary, Arbitrary.arbitrary
 
-import au.com.cba.omnia.omnitool.{Result, ResultantMonad, ResultantMonadOps, ResultantOps}
+import au.com.cba.omnia.omnitool.{Result, ResultantMonad, ResultantMonadOps, ResultantOps, ToResultantMonadOps}
 import au.com.cba.omnia.omnitool.test.Arbitraries._
 
 /** Dumpy implementation of an instance of a ResultantMonad. */
@@ -29,8 +29,8 @@ case class Resultant[A](f: Int => Result[A]) {
 }
 
 /** Arbitraries and typeclass implementations of [[Resultant]]. */
-object Resultant {
-  implicit def ResultantResultantMonad: ResultantMonad[Resultant] = new ResultantMonad[Resultant] {
+object Resultant extends ResultantOps[Resultant] with ToResultantMonadOps {
+  implicit val monad: ResultantMonad[Resultant] = new ResultantMonad[Resultant] {
     /** Similar to a `Monad.point` but expects a `Result`. */
     def rPoint[A](v: => Result[A]): Resultant[A] = Resultant(_ => v)
 
@@ -39,9 +39,6 @@ object Resultant {
       Resultant(x => f(ma.f(x)).f(x))
   }
 
-  implicit def ToResultantOps(v: Resultant.type): ResultantOps[Resultant.type, Resultant] =
-    new ResultantOps(v)
-
   implicit def ResultantEqual[A]: Equal[Resultant[A]] = {
     val i = Random.nextInt
     Equal.equal[Resultant[A]]((a, b) => a.f(i) == b.f(i))
@@ -49,5 +46,4 @@ object Resultant {
 
   implicit def ResultantArbitrary[A : Arbitrary]: Arbitrary[Resultant[A]] =
     Arbitrary(arbitrary[Result[A]].map(r => Resultant(_ => r)))
-
 }

--- a/core/src/test/scala/au/com/cba/omnia/omnitool/test/ResultantMonadSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/omnitool/test/ResultantMonadSpec.scala
@@ -14,13 +14,13 @@
 
 package au.com.cba.omnia.omnitool.test
 
+import scalaz._, Scalaz._
 import scalaz.\&/.{This, That}
 
 import org.specs2.{Specification, ScalaCheck}
 import org.specs2.matcher.{TerminationMatchers, ThrownExpectations}
 
 import au.com.cba.omnia.omnitool.{Result, Ok, Error, OmnitoolTest}
-import au.com.cba.omnia.omnitool.ResultantMonadSyntax._
 import au.com.cba.omnia.omnitool.test.Arbitraries._
 import au.com.cba.omnia.omnitool.test.OmnitoolProperties.resultantMonad
 
@@ -30,22 +30,22 @@ Resultant Monad
 ===============
 
 Resultant Monad should:
-  obey resultant monad laws (monad and plus laws)                                              ${resultantMonad.laws[Resultant]}
-  have safe mapping                                                                            $safeMap
-  map                                                                                          $map
-  have safe flatMap                                                                            $safeFlatMap
-  map accross results                                                                          $rMap
-  andThen                                                                                      $andThen
-  plus and or are the same                                                                     $plus
-  or / ||| are the same                                                                        $or
-  allow setting an error message                                                               $setMessage
-  allow adding an error message                                                                $addMessage
-  recoverWith for all cases is the same as |||                                                 $recoverWith
-  recoverWith only recovers the specified error                                                $recoverWithSpecific
-  onException does not change the result and performs the provided action on error             $onException
-  ensuring always perform the expected action                                                  $ensuringAlwaysAction
-  ensuring fails if the action fails and returns either the original error or the action error $ensuringError
-  bracket is syntactic sugar for `ensuring` and `flatMap`                                      $bracket
+  obey resultant monad laws (monad and plus laws)                                            ${resultantMonad.laws[Resultant]}
+  have safe mapping                                                                          $safeMap
+  map                                                                                        $map
+  have safe flatMap                                                                          $safeFlatMap
+  map accross results                                                                        $rMap
+  andThen                                                                                    $andThen
+  plus and or are the same                                                                   $plus
+  allow setting an error message                                                             $setMessage
+  allow adding an error message                                                              $addMessage
+  recoverWith for all cases is the same as or                                                $recoverWith
+  recoverWith only recovers the specified error                                              $recoverWithSpecific
+  onException does not change the result and performs the provided action on error           $onException
+  ensure always perform the expected action                                                  $ensureAlwaysAction
+  ensure fails if the action fails and returns either the original error or the action error $ensureError
+  bracket is syntactic sugar for `ensure` and `flatMap`                                      $bracket
+>>>>>>> Fixes clashes with Scalaz implicits.
 
 """
 
@@ -79,6 +79,7 @@ Resultant Monad should:
     x <+> y must equal(x or y)
   )
 
+<<<<<<< HEAD
   def or = prop((x: Resultant[Int], y: Resultant[Int]) =>
     x or y must equal(x ||| y)
   )
@@ -91,8 +92,10 @@ Resultant Monad should:
     Resultant.result(x).addMessage(msg) must beResult(x.addMessage(msg))
   )
 
+=======
+>>>>>>> Fixes clashes with Scalaz implicits.
   def recoverWith =  prop((x: Resultant[Int], y: Resultant[Int]) =>
-    x.recoverWith { case _ => y} must equal (x ||| y)
+    x.recoverWith { case _ => y} must equal (x or y)
   )
 
   def recoverWithSpecific = {
@@ -115,20 +118,20 @@ Resultant Monad should:
     }
   })
 
-  def ensuringAlwaysAction = prop ((x: Resultant[Int]) => {
+  def ensureAlwaysAction = prop ((x: Resultant[Int]) => {
     var flag = false
-    val actual = x.ensuring(Resultant(_ => { flag = true; Result.ok(2) }))
+    val actual = x.ensure(Resultant(_ => { flag = true; Result.ok(2) }))
 
     actual must equal(x)
     flag must beTrue
 
   })
 
-  def ensuringError = prop ((x: Resultant[Int], y: Resultant[Int]) => {
-    x.ensuring(y) must equal (x.flatMap(_ => y.flatMap(_ => x)))
+  def ensureError = prop ((x: Resultant[Int], y: Resultant[Int]) => {
+    x.ensure(y) must equal (x.flatMap(_ => y.flatMap(_ => x)))
   })
 
   def bracket = prop ((x: Resultant[Int], y: Resultant[Int], z: Resultant[Int]) =>
-    x.bracket(_ => y)(_ => z) must equal (x.flatMap(_ => z).ensuring(y))
+    x.bracket(_ => y)(_ => z) must equal (x.flatMap(_ => z).ensure(y))
   )
 }

--- a/core/src/test/scala/au/com/cba/omnia/omnitool/test/ResultantMonadSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/omnitool/test/ResultantMonadSpec.scala
@@ -45,7 +45,6 @@ Resultant Monad should:
   ensure always perform the expected action                                                  $ensureAlwaysAction
   ensure fails if the action fails and returns either the original error or the action error $ensureError
   bracket is syntactic sugar for `ensure` and `flatMap`                                      $bracket
->>>>>>> Fixes clashes with Scalaz implicits.
 
 """
 
@@ -79,11 +78,6 @@ Resultant Monad should:
     x <+> y must equal(x or y)
   )
 
-<<<<<<< HEAD
-  def or = prop((x: Resultant[Int], y: Resultant[Int]) =>
-    x or y must equal(x ||| y)
-  )
-
   def setMessage = prop((x: Result[Int], msg: String) =>
     Resultant.result(x).setMessage(msg) must beResult(x.setMessage(msg))
   )
@@ -92,8 +86,6 @@ Resultant Monad should:
     Resultant.result(x).addMessage(msg) must beResult(x.addMessage(msg))
   )
 
-=======
->>>>>>> Fixes clashes with Scalaz implicits.
   def recoverWith =  prop((x: Resultant[Int], y: Resultant[Int]) =>
     x.recoverWith { case _ => y} must equal (x or y)
   )

--- a/core/src/test/scala/au/com/cba/omnia/omnitool/test/ResultantOpsSpec.scala
+++ b/core/src/test/scala/au/com/cba/omnia/omnitool/test/ResultantOpsSpec.scala
@@ -14,6 +14,7 @@
 
 package au.com.cba.omnia.omnitool.test
 
+import scalaz._, Scalaz._
 import scalaz.\&/.{Both, This, That}
 import scalaz.scalacheck.ScalazProperties.{monad, plus}
 
@@ -21,7 +22,6 @@ import org.specs2.{Specification, ScalaCheck}
 import org.specs2.matcher.{TerminationMatchers, ThrownExpectations}
 
 import au.com.cba.omnia.omnitool.{Result, Ok, Error, OmnitoolTest}
-import au.com.cba.omnia.omnitool.ResultantMonadSyntax._
 import au.com.cba.omnia.omnitool.test.Arbitraries._
 
 class ResultantOpsSpec extends OmnitoolTest with ResultantMatchers { def is = s2"""


### PR DESCRIPTION
When importing scalaz syntax implicits at the same time as the resultant
monad implicits there would be clashes.

This fixes the clashes by:
* Turning ResultantOps into a class that the companion object inherits
  from.
* Changing ResultantMonadSyntax so that the companion object mixes in
  the implicit conversion trait.
* Renaming `ensuring` to `ensure` in ResultantMonadSyntax to avoid
  clashing with the inbuilt scala `ensuring`.  This closes #17.
* Removing the `|||` in ResultantMonadSyntax to avoid clashing with the
  `|||` operator in Scalaz ChoiceOps.