### PR TITLE
Removes ToMonadOps and ToPlusOps from ToResultantMonadOps.

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantMonadSyntax.scala
+++ b/core/src/main/scala/au/com/cba/omnia/omnitool/ResultantMonadSyntax.scala
@@ -102,7 +102,7 @@ final class ResultantMonadOps[M[_], A](val self: M[A])(implicit val M: Resultant
   * The usual use of this is to mix it into the companion object to ensure the implicit resolution
   * priority does not clash with Scalaz.
   */
-trait ToResultantMonadOps extends ToMonadOps with ToPlusOps {
+trait ToResultantMonadOps {
   /** Pimps a [[ResultantMonad]] to have access to the functions in [[ResultantMonadOps]]. */
   implicit def ToResultantMonadOps[M[_], A](v: M[A])(implicit M0: ResultantMonad[M]): ResultantMonadOps[M, A] =
     new ResultantMonadOps[M, A](v)

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.8.1"
+version in ThisBuild := "1.9.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
`ToResultantMonadOps` doesn't need to extend `ToMonadOps` and`ToPlusOps`. Instead these can be provided by Scalaz imports.

Based on my tests so far this doesn't seem to brake anything for the Hdfs, Hive and DB monad except you might have to import scalaz. It also avoids problems in the case of execution.