### PR TITLE
Updating to latest uniform

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -28,7 +28,7 @@ object build extends Build {
       updateOptions := updateOptions.value.withCachedResolution(true)
     )
 
-  val omniaTestVersion = "2.4.2-20160117232959-9cbba1d"
+  val omniaTestVersion = "2.4.3-20160307003143-c7905df"
 
   lazy val root =
     Project(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@
 
 resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
 
-val uniformVersion = "1.6.0-20160104234203-3ff47bf"
+val uniformVersion = "1.8.0-20160222014915-84418ca"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.13.0"
+version in ThisBuild := "1.13.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Bumping the `uniform`'s version to v1.8.0.
`uniform` v1.8.0 updates the version of `joda-time`, Bumping version of `uniform` to avoid conflicts in the downstream projects.