### PR TITLE
ResultantMonad instance for Result itself

### DIFF
--- a/core/src/main/scala/au/com/cba/omnia/omnitool/Result.scala
+++ b/core/src/main/scala/au/com/cba/omnia/omnitool/Result.scala
@@ -235,6 +235,12 @@ object Result {
   def prevent(fail: Boolean, message: String): Result[Unit] =
     guard(!fail, message)
 
+  /** ResultantMonad instance for Result. */
+  implicit def ResultResultantMonad: ResultantMonad[Result] = new ResultantMonad[Result] {
+    def rPoint[A](v: => Result[A]): Result[A] = v
+    def rBind[A, B](ma: Result[A])(f: Result[A] => Result[B]): Result[B] = f(ma)
+  }
+
   /** scalaz Monad instance for Result. */
   implicit def ResultMonad: Monad[Result] = new Monad[Result] {
     def point[A](v: => A) = ok(v)

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.13.1"
+version in ThisBuild := "1.14.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
In order to support the ResultantMonadSyntax on pure results, I'd like to add this implicit val.

This allows us to leverage nice features such as using *bracket* over unsafe operations, e.g:
```scala
Result.safe(initSomething()).bracket(_.release())(_.doThings())
```