### PR TITLE
CDH 5.13.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@
 
 resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
 
-val uniformVersion = "1.15.1-20170426071414-6d891a6"
+val uniformVersion = "1.16.0-20180123221516-1f65521-cdh-513"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.14.9"
+version in ThisBuild := "1.15.0"
 
 localVersionSettings
 


### PR DESCRIPTION
Driven by [Uniform PR #103](https://github.com/CommBank/uniform/pull/103) .

Upgrades libraries to CDH 5.13.0, as per:
 - https://archive.cloudera.com/cdh5/cdh/5/hadoop/hadoop-project-dist/hadoop-common/dependency-analysis.html
 - https://www.cloudera.com/documentation/enterprise/release-notes/topics/cm_vd_cdh_package_tarball_513.html